### PR TITLE
Update lore and rename Alenya_Sylph.cfg to Alenya_High_Sorceress.cfg

### DIFF
--- a/units/Alenya_High_Sorceress.cfg
+++ b/units/Alenya_High_Sorceress.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-units
 [unit_type]
     id=Alenya Elvish Sylph
-    name= _ "female^Elvish Sylph"
+    name= _ "female^Elvish High Sorceress"
     race=elf
     gender=female
     image="units/elves-wood/sylph.png"
@@ -25,7 +25,7 @@
 
     cost=67
     usage=mixed fighter
-    description= _ "Rarely seen, the sage-like Sylphs are masters of both their faerie and mundane natures. They are possessed of wondrous, and sometimes terrifying powers. Legends concerning these have given other races a healthy fear of the elves."
+    description= _ "Experienced elven spellcasters are masters of both faerie and mundane magical forces, with deep understanding of the intricacies involved. Often possessing wondrous, and sometimes terrifying powers, tales of their epic deeds have given other races a healthy fear of the elves."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
     [portrait]
         size=400


### PR DESCRIPTION
Lore update: as I mentioned in discord, it's best to not use the type "Sylph" for L4 Alenya. I renamed it to "High Sorceress" instead. IMO Sylphs are people whose pursue knowledge at all costs, even sacrificing their vision in the process. I fail to see how they could be attached to any sort of worldly desire, let alone romance.