### PR TITLE
Fix scenario 18

### DIFF
--- a/scenarios/18_Besieged.cfg
+++ b/scenarios/18_Besieged.cfg
@@ -542,6 +542,9 @@
             x,y=5,3
             radius=9
         [/filter_location]
+        [not]
+            side=1
+        [/not]
         animate=yes
     [/kill]
 


### PR DESCRIPTION
Side 1 units (notably heroes) could be killed when Myra unleash the gem power, potentially breaking subsequent scenario.
I added a filter to not hurt side 1 units to prevent that.