### PR TITLE
Fix scenario Fading Flames

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 Changelog
 
+v 1.0.11
+- Scenarios:
+    - Fixed scenario 32 being broken by bugfix of version 1.0.10.
+
 v 1.0.10
 - Deprecation fixes
 - Remove duplicate images with WoL and add missing ones

--- a/scenarios/32_Fading_Of_A_Flame.cfg
+++ b/scenarios/32_Fading_Of_A_Flame.cfg
@@ -323,11 +323,18 @@
     [/event]
 
     [event]
-        name=time over, last breath
+        name=last breath
 
         [filter]
             id=Lumens
         [/filter]
+        [fire_event]
+            name=time over
+        [/fire_event]
+    [/event]
+
+    [event]
+        name=time over
 
         [message]
             speaker=Lumens


### PR DESCRIPTION
Scenario was broken by a bugfix in the last version.
I fixed the bugfix by separating the two events.