### PR TITLE
Fix duplicate attacks of Myra (again)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changelog
 
+v 1.0.11
+- Fix Myra getting duplicate attacks (again)
+
 v 1.0.10
 - Deprecation fixes
 - Remove duplicate images with WoL and add missing ones

--- a/scenarios/21_The_Will_Of_The_Naiad_b.cfg
+++ b/scenarios/21_The_Will_Of_The_Naiad_b.cfg
@@ -166,22 +166,14 @@
             [filter]
                 id=Myra
             [/filter]
-            [object]
-                id=dragon_transformation
-                duration=forever
-                silent=yes
-                [filter]
-                    id=Maat
-                [/filter]
-                [effect]
-                    apply_to=remove_attacks
-                    name=soul explosion amla
-                [/effect]
-                [effect]
-                    apply_to=remove_attacks
-                    name=degeneration_amla
-                [/effect]
-            [/object]
+            [effect]
+                apply_to=remove_attacks
+                name=soul explosion amla
+            [/effect]
+            [effect]
+                apply_to=remove_attacks
+                name=degeneration_amla
+            [/effect]
             [effect]
                 apply_to=type
                 name=Dragon Sorceress


### PR DESCRIPTION
Bad copy-paste was causing only half of the object to have an effect