### PR TITLE
13_Twilight_Of_The_Kingdoms.cfg: don't skip bonus gold

### DIFF
--- a/scenarios/13_Twilight_Of_The_Kingdoms.cfg
+++ b/scenarios/13_Twilight_Of_The_Kingdoms.cfg
@@ -661,7 +661,6 @@
         [/message]
         [endlevel]
             result=victory
-            bonus=no
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
     [/event]


### PR DESCRIPTION
If time runs out, there will be no turns to contribute a bonus any way. But if the player defeats the dragon early, they should be rewarded (its death triggers the same event).