### PR TITLE
Nature_Prophet: fixed thorn progression

### DIFF
--- a/units/heroes-windsong/Nature_Prophet.cfg
+++ b/units/heroes-windsong/Nature_Prophet.cfg
@@ -69,7 +69,7 @@ Unlike Envoys, Prophets have much time to study the arts of leadership and heali
         type=pierce
         range=ranged
         [specials]
-            {WEAPON_SPECIAL_MAGICAL}
+            {WEAPON_SPECIAL_MARKSMAN}
         [/specials]
         damage=7
         number=4


### PR DESCRIPTION
The level3 version has it as marksman and an AMLA is available to turn it magical. So there's no good justification for the level2 unit to be better in this regard.